### PR TITLE
Close _SESSION.session in clear_session

### DIFF
--- a/keras/backend.py
+++ b/keras/backend.py
@@ -276,7 +276,9 @@ def clear_session():
   _GRAPH.graph = None
   tf.compat.v1.reset_default_graph()
   reset_uids()
-  _SESSION.session = None
+  if _SESSION.session is not None:
+    _SESSION.session.close()
+    _SESSION.session = None
   graph = get_graph()
   with graph.as_default():
     _DUMMY_EAGER_GRAPH.learning_phase_is_set = False


### PR DESCRIPTION
Thanks to nostalgebraist for pointing out this bug:  
https://nostalgebraist.tumblr.com/post/641628845811908608

`clear_session` sets `_SESSION.session` to `None`. But since that may have circular references, that's not sufficient to get it garbage collected immediately. The documentation for `Session` notes that this is important:  
https://www.tensorflow.org/api_docs/python/tf/compat/v1/Session

> A session may own resources, such as tf.Variable, tf.queue.QueueBase, and tf.compat.v1.ReaderBase. It is important to release these resources when they are no longer required. To do this, either invoke the tf.Session.close method on the session, or use the session as a context manager.